### PR TITLE
Feat-better-input

### DIFF
--- a/src/3/Warehouse/WarehouseM.lua
+++ b/src/3/Warehouse/WarehouseM.lua
@@ -102,6 +102,7 @@ end
 ---@return table<string,a546.TransferTicketM>|nil
 ---@private
 function WarehouseM:getResourceTypeTicket(containers, filter)
+    containers:refresh()
     local inputResourceType = containers:getResourceType()
     if not next(inputResourceType) then -- 不能存储任何资源，可能是容器没有初始化
         log.warn(("For some reason container: %s can't storage any resource"):format(containers.peripheralName))


### PR DESCRIPTION
该PR修改了`WarehouseW`的`input`函数，使其不再像之前那样随机选一个合适的容器存储输入的资源；现在`input`会尝试在随机选定的内部容器不能储存所有待输入的资源时随机选择另一个容器储存带输入资源。`input`默认会尝试7次，可通过模块内的`inputMaxTry`配置。