### PR TITLE
Add TransferControl for fine-grained resource transfer allocation

### DIFF
--- a/src/2/ContainerStack/TransferTicketM.lua
+++ b/src/2/ContainerStack/TransferTicketM.lua
@@ -3,22 +3,29 @@ local Object = require("lib.Object")
 local itemCommand = require("1.commands.TransferSlotToInventory")
 local fluidCommand = require("1.commands.TransferFluid")
 local invoker = require("1.CommandInvoker")
+local TransferControl = require("2.TransferControl")
 
 local expirationTime = 5
 
 ---@alias LockReceipt string # 票据
 
+---@alias TransferControlCallBack fun(yesJustIceInHere:a546.TransferControl)
+
 ---@class a546.TransferTicketM
 ---@field private containerStack a546.ContainerStackM
 ---@field private receipt LockReceipt
 ---@field private used boolean
+---@field private transferControl TransferControlCallBack
 local TransferTicketM = Object:extend()
 
----@cast TransferTicketM +fun(containerStack:a546.ContainerStackM,receipt:Receipt):a546.TransferTicketM
-function TransferTicketM:new(containerStack, receipt)
+---@cast TransferTicketM +fun(containerStack:a546.ContainerStackM,receipt:Receipt,transferControl?:TransferControlCallBack):a546.TransferTicketM
+function TransferTicketM:new(containerStack, receipt, TransferControl)
     self.containerStack = containerStack
     self.receipt = receipt
     self.createdAt = os.epoch("local")
+    self.transferControl = TransferControl or function()
+
+    end
     self.used = false
 end
 
@@ -52,11 +59,19 @@ function TransferTicketM:use(targetPeripheralName)
     self.used = true
     -- 已验证票据可用，所以reserve必不为nil
     local reserve = self.containerStack:getReserve(self.receipt)
+    ---@cast reserve -nil
+    local commandInfoList = {}
+    local tempControl = TransferControl(reserve, commandInfoList, self.containerStack.peripheralName,
+        targetPeripheralName)
+    self.transferControl(tempControl)
+    tempControl:defaultAllocate()
+    ---@cast commandInfoList a546.CommandInfo[]
     local workerInvoker = invoker()
+    --- 这个表用来储存转移资源的数量和槽位，以便后续检查传输结果是否正确和精细消耗资源
     ---@type table<number,{slotOrName:SlotOrName,info:{name:string,quantity:number}}>
     local reserveList = {}
-    ---@cast reserve -nil
-    for slotOrName, info in pairs(reserve) do
+    for index, info in ipairs(commandInfoList) do
+        --[[
         table.insert(reserveList, { slotOrName = slotOrName, info = info })
         if type(slotOrName) == "string" then
             workerInvoker:addCommand(fluidCommand(self.containerStack.peripheralName, targetPeripheralName, info
@@ -66,6 +81,9 @@ function TransferTicketM:use(targetPeripheralName)
             workerInvoker:addCommand(itemCommand(self.containerStack.peripheralName, targetPeripheralName, slotOrName,
                 info.quantity))
         end
+        ]]
+        table.insert(reserveList, { slotOrName = info.slotOrName, info = { name = info.name, quantity = info.quantity } })
+        workerInvoker:addCommand(info.command)
     end
     local invokerResult = workerInvoker:processAll()
     -- 用于储存当前支票是否传输了所有预定传输的资源

--- a/src/2/TransferControl.lua
+++ b/src/2/TransferControl.lua
@@ -1,0 +1,117 @@
+local Object                  = require("lib.Object")
+local TransferSlotToInventory = require("1.commands.TransferSlotToInventory")
+local log                     = require("lib.log")
+local TransferSlotToSlot      = require("1.commands.TransferSlotToSlot")
+local TransferFluid           = require("1.commands.TransferFluid")
+local util                    = require("lib.util")
+
+---@class a546.CommandInfo
+---@field command a546.TransferCommandBase
+---@field slotOrName number|string
+---@field name string
+---@field quantity number
+
+---@class a546.TransferControl:Object
+---@overload fun(resourceList:searchResult, commandStorageList:table, source:string, target:string):a546.TransferControl
+local out                     = Object:extend()
+
+---@param resourceList searchResult
+---@param commandStorageList a546.TransferCommandBase[]
+---@param source string 原容器名
+---@param target string 目标容器名
+---@protected
+function out:new(resourceList, commandStorageList, source, target)
+    ---@private
+    self.resourceList = resourceList
+    ---@private
+    self.command = commandStorageList
+    ---@private
+    self.source = source
+    ---@private
+    self.target = target
+end
+
+--- 自动放入目标容器，不在意目标槽位和源槽位资源数量
+---@param slot integer
+function out:to(slot)
+    if not self.resourceList[slot] then
+        log.error(("Attempt to allocate non-existence resource: slot %d."):format(slot))
+        return
+    end
+    ---@type a546.CommandInfo
+    local tempStruct = {
+        command = TransferSlotToInventory(self.source, self.target, slot),
+        slotOrName = slot,
+        name = self.resourceList[slot].name,
+        quantity = self.resourceList[slot].quantity
+    }
+    table.insert(self.command, tempStruct)
+    self.resourceList[slot] = nil
+end
+
+--- 详细分配资源去向，可以指定目标槽位和具体数量
+---@param slot integer
+---@param targetSlot integer
+---@param quantity? integer
+function out:toSlot(slot, targetSlot, quantity)
+    if not self.resourceList[slot] then
+        log.error(("Attempt to allocate non-existence resource: slot %d."):format(slot))
+        return
+    end
+    if quantity and quantity <= 0 then
+        log.error(("Attempt to allocate not legal quantity: %d"):format(quantity))
+        return
+    end
+    if quantity and self.resourceList[slot].quantity < quantity then
+        log.error(("Ask %d resource but only have %d resource"):format(quantity, self.resourceList[slot].quantity))
+        return
+    end
+    ---@type a546.CommandInfo
+    local tempStruct = {
+        command = TransferSlotToSlot(self.source, slot, self.target, targetSlot, quantity),
+        slotOrName = slot,
+        name = self.resourceList[slot].name,
+        quantity = quantity or self.resourceList[slot].quantity
+    }
+    table.insert(self.command, tempStruct)
+    if not quantity or quantity == self.resourceList[slot].quantity then
+        self.resourceList[slot] = nil
+    elseif self.resourceList[slot].quantity > quantity then
+        self.resourceList[slot].quantity = self.resourceList[slot].quantity - quantity
+    end
+end
+
+function out:defaultAllocate()
+    for slotOrName, resource in pairs(self.resourceList) do
+        if type(slotOrName) == "number" then
+            ---@type a546.CommandInfo
+            local tempStruct = {
+                command = TransferSlotToInventory(self.source, self.target, slotOrName),
+                slotOrName = slotOrName,
+                name = resource.name,
+                quantity = resource.quantity
+            }
+            table.insert(self.command, tempStruct)
+        else
+            ---@cast slotOrName string
+            ---@type a546.CommandInfo
+            local tempStruct = {
+                command = TransferFluid(self.source, self.target, resource.quantity, slotOrName),
+                slotOrName = slotOrName,
+                name = resource.name,
+                quantity = resource.quantity
+            }
+            table.insert(self.command, tempStruct)
+        end
+    end
+    self.resourceList = {}
+end
+
+--- 获取资源列表
+---@return searchResult
+function out:getResourceList()
+    local proxy = util.readOnly(self.resourceList)
+    return proxy
+end
+
+return out

--- a/src/lib/util.lua
+++ b/src/lib/util.lua
@@ -59,4 +59,71 @@ function out.len(tTable)
     return i
 end
 
+local cache = setmetatable({}, { __mode = "kv" })
+--- 返回一个表的只读代理
+---@generic T:table
+---@param theTable T
+---@return T
+function out.readOnly(theTable)
+    if cache[theTable] then
+        return cache[theTable]
+    end
+    local proxy = {}
+    local pMetaTable = {}
+
+    cache[theTable] = proxy -- 缓存真实表
+    cache[proxy] = proxy    -- 缓存只读代理
+
+    pMetaTable.__index = function(t, k)
+        local v = theTable[k]
+        if type(v) == "table" then
+            return out.readOnly(v)
+        elseif type(v) == "function" then
+            return function(firstParam, ...)
+                -- local meta = getmetatable(firstParam)
+                -- while meta do
+                --     if meta == proxy then
+                --         return v(theTable, ...)
+                --     end
+                --     meta = getmetatable(meta)
+                -- end
+                if firstParam == proxy then
+                    return v(theTable, ...)
+                else
+                    return v(firstParam, ...)
+                end
+            end
+        else
+            return v
+        end
+    end
+    pMetaTable.__newindex = function(t, k, v)
+        error(("Can't set table: %s, key: %s to value: %s"):format(tostring(theTable), tostring(k), tostring(v)), 2)
+    end
+    pMetaTable.__len = function(t)
+        return #theTable
+    end
+    pMetaTable.__pairs = function()
+        return function(_, oldValue)
+            local key, newValue = next(theTable, oldValue)
+            if type(newValue) == "table" then
+                return key, out.readOnly(newValue)
+            else
+                return key, newValue
+            end
+        end, nil, nil
+    end
+    pMetaTable.__call = function(_, ...)
+        return theTable(...)
+    end
+    local originMetaTable = getmetatable(theTable)
+    if originMetaTable then
+        pMetaTable.__metatable = out.readOnly(getmetatable(theTable))
+    else
+        pMetaTable.__metatable = {}
+    end
+    setmetatable(proxy, pMetaTable)
+    return proxy
+end
+
 return out


### PR DESCRIPTION
## Summary

引入 `TransferControl` 传输控制模块，通过回调机制让调用方可以精细控制每个资源的传输去向（目标槽位、数量等）。

## Changes

### New Features

- **`src/2/TransferControl.lua`** — 新增传输控制模块，提供：
  - `to(slot)` — 将指定槽位资源自动放入目标容器
  - `toSlot(slot, targetSlot, quantity?)` — 精细指定目标槽位和数量
  - `defaultAllocate()` — 未手动分配的资源自动按默认规则分配
  - `getResourceList()` — 获取剩余待分配资源（只读）

- **`src/lib/util.lua`** — 新增 `readOnly` 工具函数，通过元表代理返回表的只读副本

### Modifications

- **`src/2/ContainerStack/TransferTicketM.lua`** — 适配 `TransferControl`，构造函数新增可选回调参数，将原有的直接遍历分配逻辑改为通过 `TransferControl` 回调驱动

### Design

调用方通过传入回调函数获得 `TransferControl` 实例，在回调中可对每个资源槽位精细指定去向，未被手动分配的资源由 `defaultAllocate()` 统一处理。这保持了向后兼容——不传回调时行为与原来一致。