### PR TITLE
doc(meta): 不再使用 @field 注释，改用 require 声明模块导出

### DIFF
--- a/meta/AutoLogistics.lua
+++ b/meta/AutoLogistics.lua
@@ -1,17 +1,18 @@
 ---@meta
 
----@class AutoLogistics
----@field CommandInvoker        a546.CommandInvoker
----@field TransferFluid         a546.TransferFluid
----@field TransferItems         a546.TransferItems
----@field TransferSlotToInventory a546.TransferSlotToInventory
----@field TransferSlotToSlot    a546.TransferSlotToSlot
----@field Filter                a546.Filter
----@field preDefinedFilter      preDefinedFilterModule
----@field ContainerScan         containerScanModule
----@field ContainerStackM       a546.ContainerStackM
----@field ResourceManager       a546.ResourceManager
----@field TransferTicketM       a546.TransferTicketM
 local M = {}
+
+M.CommandInvoker = require("1.CommandInvoker")
+M.TransferFluid = require("1.commands.TransferFluid")
+M.TransferItems = require("1.commands.TransferItems")
+M.TransferSlotToInventory = require("1.commands.TransferSlotToInventory")
+M.TransferSlotToSlot = require('1.commands.TransferSlotToSlot')
+
+M.Filter = require("2.Filter")
+M.preDefinedFilter = require("2.preDefinedFilter")
+M.ContainerScan = require("2.ContainerStack.ContainerScan")
+M.ContainerStackM = require("2.ContainerStack.ContainerStackM")
+M.ResourceManager = require("2.ContainerStack.ResourceManager")
+M.TransferTicketM = require("2.ContainerStack.TransferTicketM")
 
 return M


### PR DESCRIPTION
## 概述

将 `meta/AutoLogistics.lua` 元文件从 `---@field` 注解风格改为直接使用 `require()` 调用。

## 变更原因

原先使用 `---@class` + `---@field` 的方式声明模块导出，但这种方式在将本仓库作为子模块导入时，LuaLS 无法正确解析类型（AI之前自定义了类型名，删除后无法使用`---@filed`表明类型，我懒得研究，就改成用`require`了）。改为 `require()` 调用后，LuaLS 可以追踪实际的模块路径并推断正确的类型。

## 变更内容

- 移除 `---@class AutoLogistics` 及所有 `---@field` 注解
- 使用 `local M = {}` + `M.XXX = require(...)` 模式声明模块导出
- 保持所有导出模块名称不变